### PR TITLE
Improve frontend UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@types/node": "^20.10.4",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1407,6 +1408,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.9",
@@ -3470,6 +3481,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "@types/node": "^20.10.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,6 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
 import Sidebar from "./components/Sidebar";
-import { Card, CardContent } from "./components/ui/card";
-import { Button } from "./components/ui/button";
-import { Badge } from "./components/ui/badge";
 
 type Post = {
   id: string;
@@ -53,7 +50,8 @@ export default function App() {
     try {
       const res = await axios.get(`/api/posts/${postId}/comments`);
       setComments((prev) => ({ ...prev, [postId]: res.data }));
-    } catch (e) {
+    } catch (err) {
+      console.error(err);
       setComments((prev) => ({ ...prev, [postId]: [] }));
     }
     setLoadingComments(null);
@@ -64,7 +62,8 @@ export default function App() {
     try {
       const res = await axios.post("/api/generate-reply", { text: commentText });
       setAiReply((prev) => ({ ...prev, [commentId]: res.data.reply }));
-    } catch (e) {
+    } catch (err) {
+      console.error(err);
       setAiReply((prev) => ({ ...prev, [commentId]: "AI error." }));
     }
     setLoadingAi(null);
@@ -78,132 +77,98 @@ export default function App() {
       });
       setReplyInput((prev) => ({ ...prev, [commentId]: "" }));
       alert("Reply posted!");
-    } catch (e) {
+    } catch (err) {
+      console.error(err);
       alert("Failed to post reply.");
     }
     setPostingReply(null);
   };
 
   return (
-    <div className="flex min-h-screen bg-gradient-background">
+    <div className="app-container">
       <Sidebar selected={selectedPlatform} onSelect={setSelectedPlatform} />
-      <main className="flex-1 p-6 md:p-12">
-        <div className="max-w-3xl mx-auto">
-          <h1 className="text-3xl md:text-4xl font-bold text-primary mb-8 text-center tracking-tight flex items-center justify-center gap-3">
-            <span role="img" aria-label="fb">📘</span> 
+      <main className="main">
+        <div className="container">
+          <h1>
+            <span role="img" aria-label="fb">📘</span>
             {selectedPlatform.charAt(0).toUpperCase() + selectedPlatform.slice(1)} Page Monitor
           </h1>
           {posts.length === 0 && (
-            <Card className="bg-gradient-card glass-card shadow-card mb-8">
-              <CardContent className="p-8 text-center text-muted-foreground">
-                Loading posts...
-              </CardContent>
-            </Card>
+            <div className="post-card">Loading posts...</div>
           )}
           {posts.map((post) => (
-            <Card
-              key={post.id}
-              className="mb-10 bg-gradient-card glass-card shadow-card transition-smooth hover:shadow-elegant"
-            >
-              <CardContent className="pt-8 pb-4 px-8">
-                <div className="flex flex-col gap-1">
-                  <span className="text-lg md:text-xl font-semibold text-primary-foreground">
-                    {post.message || <i>No text</i>}
-                  </span>
-                  <span className="text-xs text-muted-foreground mb-2">
-                    {new Date(post.created_time).toLocaleString()}
-                  </span>
-                  {/* Post image */}
-                  {post.attachments?.data?.[0]?.media?.image?.src && (
-                    <img
-                      src={post.attachments.data[0].media.image.src}
-                      alt="Post"
-                      className="rounded-lg shadow-card my-3 max-w-full"
-                      style={{ maxWidth: 350 }}
-                    />
-                  )}
-                  <Button
-                    variant="default"
-                    size="sm"
-                    className="mt-2 w-fit bg-gradient-primary shadow-elegant"
-                    onClick={() => loadComments(post.id)}
-                    disabled={loadingComments === post.id}
-                  >
-                    {loadingComments === post.id ? "Loading..." : "Show Comments"}
-                  </Button>
+            <div key={post.id} className="post-card">
+              <div className="post-content">
+                <div className="post-message">{post.message || <i>No text</i>}</div>
+                <div className="post-meta">
+                  {new Date(post.created_time).toLocaleString()}
                 </div>
-                {/* Comments */}
-                <div className="mt-5 space-y-5">
-                  {(comments[post.id] || []).map((comment) => (
-                    <Card
-                      key={comment.id}
-                      className="glass-card bg-gradient-card shadow-card border-primary/40"
-                    >
-                      <CardContent className="pt-4 pb-3 px-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Badge variant="secondary" className="mr-1">
-                            {comment.from?.name || "Anonymous"}
-                          </Badge>
-                          <span className="text-xs text-muted-foreground">
-                            {comment.id.slice(-4)}
-                          </span>
-                        </div>
-                        <div className="text-base text-card-foreground mb-2">
-                          {comment.message}
-                        </div>
-                        <div className="flex items-center gap-2 mt-1 flex-wrap">
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            className="transition-smooth"
-                            onClick={() =>
-                              handleSuggestReply(comment.id, comment.message)
-                            }
-                            disabled={loadingAi === comment.id}
-                          >
-                            {loadingAi === comment.id
-                              ? "Thinking..."
-                              : "Suggest AI Reply"}
-                          </Button>
-                          {aiReply[comment.id] && (
-                            <span className="ml-2 text-primary text-sm italic">
-                              💡 {aiReply[comment.id]}
-                            </span>
-                          )}
-                        </div>
-                        <div className="mt-2 flex items-center gap-2">
-                          <input
-                            className="w-56 rounded-md border border-input px-2 py-1 text-sm bg-muted text-foreground outline-none focus:ring-2 focus:ring-primary transition-smooth"
-                            value={replyInput[comment.id] || ""}
-                            onChange={(e) =>
-                              setReplyInput((prev) => ({
-                                ...prev,
-                                [comment.id]: e.target.value,
-                              }))
-                            }
-                            placeholder="Type your reply..."
-                          />
-                          <Button
-                            variant="default"
-                            size="sm"
-                            onClick={() => handlePostReply(comment.id)}
-                            disabled={
-                              postingReply === comment.id ||
-                              !(replyInput[comment.id] || "").trim()
-                            }
-                            className="transition-smooth"
-                          >
-                            {postingReply === comment.id
-                              ? "Posting..."
-                              : "Post Reply"}
-                          </Button>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+                {post.attachments?.data?.[0]?.media?.image?.src && (
+                  <img
+                    src={post.attachments.data[0].media.image.src}
+                    alt="Post"
+                    className="post-image"
+                  />
+                )}
+                <button
+                  className="show-comments-btn"
+                  onClick={() => loadComments(post.id)}
+                  disabled={loadingComments === post.id}
+                >
+                  {loadingComments === post.id ? "Loading..." : "Show Comments"}
+                </button>
+              </div>
+              <div className="comments-list">
+                {(comments[post.id] || []).map((comment) => (
+                  <div key={comment.id} className="comment-card">
+                    <div>
+                      <span className="comment-author">
+                        {comment.from?.name || "Anonymous"}
+                      </span>
+                      <span style={{ marginLeft: 6, fontSize: 12, color: '#888ea8' }}>
+                        {comment.id.slice(-4)}
+                      </span>
+                    </div>
+                    <div>{comment.message}</div>
+                    <div className="ai-reply-row">
+                      <button
+                        className="ai-reply-btn"
+                        onClick={() => handleSuggestReply(comment.id, comment.message)}
+                        disabled={loadingAi === comment.id}
+                      >
+                        {loadingAi === comment.id ? 'Thinking...' : 'Suggest AI Reply'}
+                      </button>
+                      {aiReply[comment.id] && (
+                        <span className="ai-reply-text">💡 {aiReply[comment.id]}</span>
+                      )}
+                    </div>
+                    <div className="reply-row">
+                      <input
+                        className="reply-input"
+                        value={replyInput[comment.id] || ''}
+                        onChange={(e) =>
+                          setReplyInput((prev) => ({
+                            ...prev,
+                            [comment.id]: e.target.value,
+                          }))
+                        }
+                        placeholder="Type your reply..."
+                      />
+                      <button
+                        className="reply-btn"
+                        onClick={() => handlePostReply(comment.id)}
+                        disabled={
+                          postingReply === comment.id ||
+                          !(replyInput[comment.id] || '').trim()
+                        }
+                      >
+                        {postingReply === comment.id ? 'Posting...' : 'Post Reply'}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       </main>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { Button } from "../components/ui/button";
 import { Facebook, Instagram, Linkedin } from "lucide-react";
 
 const platforms = [
@@ -15,22 +14,18 @@ export default function Sidebar({
   onSelect: (id: string) => void;
 }) {
   return (
-    <aside className="h-screen w-24 md:w-64 bg-gradient-to-b from-blue-900 to-slate-900 rounded-2xl m-2 flex flex-col py-8 px-3 shadow-2xl glass-card">
-      <div className="mb-10">
-        <div className="text-blue-300 text-3xl font-extrabold tracking-widest ml-2">SAND</div>
-      </div>
-      <nav className="flex flex-col gap-4 w-full">
+    <aside className="sidebar">
+      <div className="logo">SAND</div>
+      <nav>
         {platforms.map((plat) => (
-          <Button
+          <button
             key={plat.id}
-            variant={selected === plat.id ? "default" : "ghost"}
-            size="lg"
-            className={`flex items-center gap-4 px-2 ${selected === plat.id ? "bg-blue-800/80 text-white shadow-lg" : "text-blue-200 hover:bg-blue-800/60"}`}
+            className={`sidebar-btn ${selected === plat.id ? 'active' : ''}`}
             onClick={() => onSelect(plat.id)}
           >
-            <plat.icon className="w-6 h-6" />
-            <span className="hidden md:inline font-semibold">{plat.label}</span>
-          </Button>
+            <plat.icon size={18} />
+            <span className="label">{plat.label}</span>
+          </button>
         ))}
       </nav>
     </aside>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -53,7 +53,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
-    const Comp = asChild ? ("span" as any) : "button";
+    const Comp: React.ElementType = asChild ? "span" : "button";
     return (
       <Comp
         ref={ref}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -242,3 +242,69 @@ h1 {
   cursor: not-allowed;
   opacity: 0.6;
 }
+
+/* Layout */
+.app-container {
+  display: flex;
+  min-height: 100vh;
+  background: #eef2f5;
+}
+
+.main {
+  flex: 1;
+  padding: 20px;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 200px;
+  background: #1f2937;
+  color: #fff;
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.logo {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 24px;
+  color: #93c5fd;
+  letter-spacing: 2px;
+}
+
+.sidebar-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.sidebar-btn:hover {
+  background: #334155;
+  color: #fff;
+}
+
+.sidebar-btn.active {
+  background: #0f172a;
+  color: #fff;
+}
+
+.sidebar-btn .label {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .sidebar {
+    width: 240px;
+  }
+  .sidebar-btn .label {
+    display: inline;
+  }
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -5,6 +5,7 @@
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["node"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- restyle the frontend using custom CSS instead of Tailwind classes
- simplify sidebar component
- update TypeScript config and install `@types/node`
- fix lint issues

## Testing
- `npm run lint`
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_688b5ccb90e08323b973f800bc606239